### PR TITLE
Add GPIO/I2C GID build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV LANG=en_US.UTF-8
 ARG USER=spot
 ARG UID=1000
 ARG GID=1000
+ARG GPIO_GID=997
+ARG I2C_GID=998
 ARG PW=micro
 ARG REPO_URL="https://github.com/saitbnzl/spot_micro"
 
@@ -21,8 +23,8 @@ RUN apt-get update && apt-get install -y \
 COPY 99-gpio.rules /etc/udev/rules.d/99-gpio.rules
 
 # 2) Create your “spot” group with GID 1000, then gpio/i2c, then useradd --gid=1000
-RUN groupadd -f -r gpio \
-  && groupadd -f -r i2c \
+RUN groupadd -f -r -g ${GPIO_GID} gpio \
+  && groupadd -f -r -g ${I2C_GID} i2c \
   && useradd -m ${USER} --uid=${UID} \
   && echo "${USER}:${PW}" | chpasswd \
   && usermod -aG gpio,i2c,sudo ${USER}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # spot_micro
 This is a collection of ROS 2 nodes for my spot micro. I run ROS 2 on the Jetson Nano in a docker container so this repo also contains a Dockerfile to run the code.
+
+## Build
+
+Build the image with your host's GPIO and I2C group IDs so that the
+container can access those devices:
+
+```bash
+docker build \
+  --build-arg GPIO_GID=$(getent group gpio | cut -d: -f3) \
+  --build-arg I2C_GID=$(getent group i2c | cut -d: -f3) \
+  -t spot_micro .
+```
+
+Supplying these IDs prevents "can not open gpiochip" errors when running
+the ROS nodes.


### PR DESCRIPTION
## Summary
- allow container `gpio`/`i2c` groups to match host via build args
- document building the image with host group IDs

## Testing
- `pytest -q spot_joints/test/test_flake8.py` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_6844ba8178b08325ae5acd704d18354f